### PR TITLE
Added support for initial command, so it can be run as `%xterm <command>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ To display a terminal, type the [magic function](http://ipython.readthedocs.io/e
 %xterm
 ```
 
+To display a terminal and immediately run a command in it, just place the command after the `%xterm` call:
+```
+%xterm ls
+```
+
 ## Tested Environments
 + [IBM Data Science Experience](https://datascience.ibm.com/)
 + Jupyter 4.3.0

--- a/notebook_xterm/terminalclient.js
+++ b/notebook_xterm/terminalclient.js
@@ -48,6 +48,8 @@ function TerminalClient(elem) {
         this.poll_server();
         console.log('Starting notebook_xterm.');
 
+        this.server_exec(PY_TERMINAL_SERVER + '.initial_transmit()');
+
     }.bind(this));
 }
 

--- a/notebook_xterm/terminalserver.py
+++ b/notebook_xterm/terminalserver.py
@@ -26,6 +26,9 @@ class TerminalServer:
             flags = fcntl(self.file, F_GETFL)
             fcntl(self.file, F_SETFL, flags | os.O_NONBLOCK)
 
+    def initial_transmit(self):
+        self.transmit(base64.b64encode(self.initial_command))
+
     def transmit(self,data):
         # data in the "channel" is b64 encoded so that control characters
         # don't get lost

--- a/notebook_xterm/xterm.py
+++ b/notebook_xterm/xterm.py
@@ -5,6 +5,8 @@ import os
 from .terminalserver import TerminalServer
 from IPython.core.display import display, HTML
 from IPython.core.magic import (Magics, magics_class, line_magic, cell_magic)
+import time
+from base64 import b64encode
 
 JS_FILE_NAME = 'terminalclient.js'
 
@@ -19,9 +21,14 @@ class Xterm(Magics):
 
         markup = """
         <div id="notebook_xterm"></div>
-        <script>{0}</script>
+        <script id="notebook_script">{0}</script>
         """.format(terminalClient_js)
         display(HTML(markup))
+        ts = self.getTerminalServer()
+        ts.initial_command = bytes(line, encoding="utf-8") + b"\r"
+
+        return self.getTerminalServer()
+        #ts.transmit(b64encode(b"ls"))
 
     def getTerminalServer(self):
         try:


### PR DESCRIPTION
This PR adds a new feature where the xterm magic can take an argument of a command to run as soon as the terminal is opened.

So, you can now run `%xterm ls` to open a xterm and immediately run the `ls` command. Very helpful for interactive documentation in a jupyter notebook, where you need to explain/document the running of terminal commands too.