### PR TITLE
Allow multiple terminals in one notebook

### DIFF
--- a/notebook_xterm/terminalclient.js
+++ b/notebook_xterm/terminalclient.js
@@ -76,6 +76,7 @@ TerminalClient.prototype.create_ui = function(elem) {
     })
     this.titleText = $('<div>').html(INITIAL_TITLE).css({float: 'left'}).appendTo(this.titleBar);
     this.comIndicator = $('<div>').html('&middot;').css({float: 'left', marginLeft: 10}).hide().appendTo(this.titleBar);
+    this.close_button = $('<div>').html('<a onclick="window.terminalClient.close()">close</a>').css({float: 'right'}).appendTo(this.titleBar);
     this.termArea = $('<div>').appendTo(this.wrap);
     return this.termArea;
 }

--- a/notebook_xterm/terminalclient.js
+++ b/notebook_xterm/terminalclient.js
@@ -13,6 +13,7 @@ function TerminalClient(elem) {
     });
 
     require(['xterm'], function(Terminal) {
+        this.div_id = elem.attr('id')
         var termArea = this.create_ui(elem);
         this.term = new Terminal({
             rows: 25,
@@ -171,11 +172,10 @@ TerminalClient.prototype.close = function() {
     console.log('Closing notebook_xterm.');
     clearTimeout(this.termPollTimer);
     this.server_exec(PY_XTERM_INSTANCE + '.deleteTerminalServer()');
-    $('#notebook_xterm').remove()
-    
+    $("#" + this.div_id).remove()
 }
 // create the TerminalClient instance (only once!)
 if (window.terminalClient) {
+    window.terminalClient.close()
     delete window.terminalClient;
 }
-window.terminalClient = new TerminalClient($('#notebook_xterm'))

--- a/notebook_xterm/terminalclient.js
+++ b/notebook_xterm/terminalclient.js
@@ -170,6 +170,7 @@ TerminalClient.prototype.close = function() {
     console.log('Closing notebook_xterm.');
     clearTimeout(this.termPollTimer);
     this.server_exec(PY_XTERM_INSTANCE + '.deleteTerminalServer()');
+    $('#notebook_xterm').remove()
     this.closed = true;
 }
 // create the TerminalClient instance (only once!)

--- a/notebook_xterm/terminalclient.js
+++ b/notebook_xterm/terminalclient.js
@@ -167,11 +167,12 @@ TerminalClient.prototype.close = function() {
     if (this.closed) {
         return;
     }
+    this.closed = true;
     console.log('Closing notebook_xterm.');
     clearTimeout(this.termPollTimer);
     this.server_exec(PY_XTERM_INSTANCE + '.deleteTerminalServer()');
     $('#notebook_xterm').remove()
-    this.closed = true;
+    
 }
 // create the TerminalClient instance (only once!)
 if (window.terminalClient) {

--- a/notebook_xterm/xterm.py
+++ b/notebook_xterm/xterm.py
@@ -5,6 +5,12 @@ import os
 from .terminalserver import TerminalServer
 from IPython.core.display import display, HTML
 from IPython.core.magic import (Magics, magics_class, line_magic, cell_magic)
+<<<<<<< HEAD
+=======
+import time
+from base64 import b64encode
+from uuid import uuid4
+>>>>>>> fb13e00... Use unique ID for each notebook_xterm div, so we can have multiple divs at a time
 
 JS_FILE_NAME = 'terminalclient.js'
 
@@ -17,11 +23,18 @@ class Xterm(Magics):
         with open(jsPath) as f:
             terminalClient_js = f.read()
 
-        markup = """
-        <div id="notebook_xterm"></div>
-        <script>{0}</script>
-        """.format(terminalClient_js)
+        unique_id = str(uuid4())
+        markup = f"""
+        <div id="notebook_xterm_{unique_id}"></div>
+        <script id="notebook_script">{terminalClient_js}
+
+        window.terminalClient = new TerminalClient($('#notebook_xterm_{unique_id}'))
+        </script>
+        """
         display(HTML(markup))
+        ts = self.getTerminalServer()
+
+        return self.getTerminalServer()
 
     def getTerminalServer(self):
         try:

--- a/notebook_xterm/xterm.py
+++ b/notebook_xterm/xterm.py
@@ -5,12 +5,8 @@ import os
 from .terminalserver import TerminalServer
 from IPython.core.display import display, HTML
 from IPython.core.magic import (Magics, magics_class, line_magic, cell_magic)
-<<<<<<< HEAD
-=======
-import time
 from base64 import b64encode
 from uuid import uuid4
->>>>>>> fb13e00... Use unique ID for each notebook_xterm div, so we can have multiple divs at a time
 
 JS_FILE_NAME = 'terminalclient.js'
 


### PR DESCRIPTION
This PR adds support for multiple xterms in one notebook. They can't all work at once - I couldn't manage to get that working - but it means if you have two cells with `%xterm` in them, then you can run one, use the terminal a bit, then run the other. When you run the second one, the first terminal will automatically close, and the second one will become active.

I've also added a manual 'close' button to the terminal interface.

This works particularly well with #5 and in the context of notebook-based documentation/training. You can have a paragraph of explanation, then a cell with `%xterm command-to-run --args` in it. The user can run that and interact with the terminal, then move on to more paragraphs of explanation below, and then another `%xterm different-command --args` cell, which they can also run to interact with that terminal.