### PR TITLE
Python3 and non-latin letters support

### DIFF
--- a/notebook_xterm/terminalclient.js
+++ b/notebook_xterm/terminalclient.js
@@ -120,7 +120,7 @@ TerminalClient.prototype.receive_data_callback = function(data) {
     }
 
     try {
-        var decoded = atob(data.content.text);
+        var decoded = decodeURIComponent(escape(window.atob(data.content.text)));
         this.term.write(decoded);
     }
     catch(e) {
@@ -147,7 +147,7 @@ TerminalClient.prototype.handle_transmit = function(data) {
     this.curPollInterval = MIN_POLL_INTERVAL;
 
     // transmit data to the server, but b64 encode it
-    this.server_exec(PY_TERMINAL_SERVER + '.transmit(b"' + btoa(data) + '")');
+    this.server_exec(PY_TERMINAL_SERVER + '.transmit(b"' + btoa(unescape(encodeURIComponent(data))) + '")');
 }
 
 TerminalClient.prototype.handle_resize = function() {

--- a/notebook_xterm/terminalserver.py
+++ b/notebook_xterm/terminalserver.py
@@ -37,7 +37,7 @@ class TerminalServer:
             data = os.read(self.fd, 8192)
         except OSError:
             data = b''
-        sys.stdout.write(base64.b64encode(data))
+        sys.stdout.write(base64.b64encode(data).decode('utf-8'))
 
     def update_window_size(self, rows, cols):
         #notify that the pty size should change to match xterm.js


### PR DESCRIPTION
Python 3 handles strings with two different types. 

    sys.stdout.write(data)

expects `type(data)` to be `<class 'str'>` and not <class 'bytes'>, so we have to tell how to decode bytes to str. See https://stackoverflow.com/a/21689447/822644

To handle non-latin letters, such as "č", some modifications had to be done in Javascript wrapper as well. `btoa` and `atob` both expect only latin letters. Usual trick is to use `unescape(encodeURIComponent(letters))` in `atob` and `decodeURIComponent(escape(bytes))` in `btoa`.